### PR TITLE
Model was crashing because of spelling error

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -13,7 +13,7 @@ module.exports = {
     },
 
     roles: {
-      collection: 'Role',
+      collection: 'Roles',
       via: 'users'
     }
   }


### PR DESCRIPTION
Was crashing because of spelling issue in model...

/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/waterline-schema/lib/waterline-schema/joinTables.js:143
    throw new Error(error);
    ^

Error: Collection user has an attribute named roles that is pointing to a collection named role which doesn't exist. You must  first create the role collection.
  at JoinTables.parseAttribute (/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/waterline-schema/lib/waterline-schema/joinTables.js:143:11)
  at /home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/waterline-schema/lib/waterline-schema/joinTables.js:83:22
  at Array.forEach (native)
  at JoinTables.buildJoins (/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/waterline-schema/lib/waterline-schema/joinTables.js:82:24)
  at new JoinTables (/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/waterline-schema/lib/waterline-schema/joinTables.js:40:23)
  at new module.exports (/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/waterline-schema/lib/waterline-schema.js:33:17)
  at [object Object].Waterline.initialize (/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/waterline/lib/waterline.js:107:17)
  at buildORM (/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/lib/hooks/orm/build-orm.js:52:15)
  at Array.async.auto.instantiatedCollections (/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/lib/hooks/orm/index.js:203:11)
  at listener (/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/async/lib/async.js:490:46)
  at /home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/async/lib/async.js:441:17
  at _each (/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/async/lib/async.js:46:13)
  at Immediate.taskComplete (/home/ubuntu/.nvm/versions/node/v4.1.1/lib/node_modules/sails/node_modules/async/lib/async.js:440:13)
  at processImmediate [as _immediateCallback](timers.js:374:17)
